### PR TITLE
Removed default value for the cron script template update_users.sh

### DIFF
--- a/templates/update_users.sh.j2
+++ b/templates/update_users.sh.j2
@@ -3,7 +3,7 @@
 set +x
 
 cd /tmp
-wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename|default('dev.yml') }} -O /tmp/users.yml
+wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename }} -O /tmp/users.yml
 
 cat << EOF > /tmp/requirements.yml
 ---


### PR DESCRIPTION
Setting default has masked the issue resulting in the incorrect users being added to systems.
Better fail early on bootstrapping for instances that have yet to update the user-data template than risk adding incorrect users.

Closes #48 