### PR TITLE
Removed default value for the cron script template update_users.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Role Variables
  - `lv_size` = volume size see `man lvcreate`
  - `lvm_disks` = list of disks to consume in lvm creation
  - `remove_password_rules` = to disable password expiry, default true
+ - `remote_user_filename` = bastion_inventory either ( dev | prod )
 
 
 Example Playbook
@@ -61,7 +62,7 @@ Including an example of how to use your role (for instance, with variables passe
 
 ```yaml
     ---
-    
+
     - hosts: localhost
       roles:
          - bootstrap
@@ -76,4 +77,3 @@ License
 -------
 
 MIT
-

--- a/templates/update_users.sh.j2
+++ b/templates/update_users.sh.j2
@@ -3,7 +3,7 @@
 set +x
 
 cd /tmp
-wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename|default('dev.yml') }} -O /tmp/users.yml
+wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename }} -O /tmp/users.yml
 
 cat << EOF > /tmp/requirements.yml
 ---


### PR DESCRIPTION
Setting default has masked the issue resulting in the incorrect users being added to systems.
Better fail early on bootstrapping for instances that have yet to update the user-data template than risk adding incorrect users.

Second attempt after previous exposed that this variable was required for the Jenkins Slave user data.

Expecting this will expose any other builds where this is not set.