### PR TITLE
added extension to users yaml file path. changed default from "dev" t…

### DIFF
--- a/templates/update_users.sh.j2
+++ b/templates/update_users.sh.j2
@@ -3,7 +3,7 @@
 set +x
 
 cd /tmp
-wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename|default('dev.yml') }} -O /tmp/users.yml
+wget https://raw.githubusercontent.com/ministryofjustice/hmpps-delius-ansible/master/group_vars/{{ remote_user_filename|default('prod') }}.yml -O /tmp/users.yml
 
 cat << EOF > /tmp/requirements.yml
 ---


### PR DESCRIPTION
…o "prod".

Both Marcus and Paul Miller have in the last 5 days had problems accessing instances to debug and develop.

Source of the issue is that the update_users cron script is failing when retrieving list of users from github repo due to missing file extension in Ansible template.

There is also an additional complexity that some instances do not provide the name of the bastion inventory (the var used in template) to the user_data script as an ansible var, hence it is falling back to a default of "dev.yml".

Will change that default to "prod".
Because we want prod to work correctly, dev instances with this issue can be fixed manually or the code updated so that the default is not required.
I would prefer to remove the default and identify where it is required but time is not available for that.