### PR TITLE
ALS-842 Use AWS time sync service for chrony, to avoid drift on servers without outbound access on port 123.

### DIFF
--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -7,7 +7,7 @@
 - name: Configure chrony to use the AWS time server
   template:
     src: chrony.conf.j2
-    dest: chrony.conf
+    dest: /etc/chrony.conf
   become: true
 
 - name: Restart chrony service

--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -3,3 +3,15 @@
 - name: Configure our timezone
   command: cp /usr/share/zoneinfo/Europe/London /etc/localtime
   become: true
+
+- name: Configure chrony to use the AWS time server
+  template:
+    src: chrony.conf.j2
+    dest: chrony.conf
+  become: true
+
+- name: Restart chrony service
+  service:
+    name: chronyd
+    state: restarted
+  become: true

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,0 +1,34 @@
+# Use AWS time sync service (https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/)
+server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking


### PR DESCRIPTION
See https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/